### PR TITLE
Feat/#3 main stock list view

### DIFF
--- a/TradeUp/TradeUp.xcodeproj/project.pbxproj
+++ b/TradeUp/TradeUp.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		042B0C9A2E227E8A00B4A017 /* FetchPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042B0C992E227E8A00B4A017 /* FetchPhase.swift */; };
+		042B0C9C2E227F2F00B4A017 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042B0C9B2E227F2F00B4A017 /* SearchView.swift */; };
+		042B0C9E2E227F3E00B4A017 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042B0C9D2E227F3E00B4A017 /* SearchViewModel.swift */; };
 		2F3D68E42E1D4210005148D9 /* TradeUpApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */; };
 		2F3D68E52E1D4210005148D9 /* Quote+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68CE2E1D4210005148D9 /* Quote+Extensions.swift */; };
 		2F3D68E62E1D4210005148D9 /* Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68D02E1D4210005148D9 /* Stubs.swift */; };
@@ -43,6 +46,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		042B0C992E227E8A00B4A017 /* FetchPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPhase.swift; sourceTree = "<group>"; };
+		042B0C9B2E227F2F00B4A017 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+		042B0C9D2E227F3E00B4A017 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeUpApp.swift; sourceTree = "<group>"; };
 		2F3D68CE2E1D4210005148D9 /* Quote+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quote+Extensions.swift"; sourceTree = "<group>"; };
 		2F3D68D02E1D4210005148D9 /* Stubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stubs.swift; sourceTree = "<group>"; };
@@ -131,6 +137,7 @@
 			isa = PBXGroup;
 			children = (
 				2F3D68D22E1D4210005148D9 /* TickerListRowData.swift */,
+				042B0C992E227E8A00B4A017 /* FetchPhase.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -149,6 +156,7 @@
 			children = (
 				2F3D68D72E1D4210005148D9 /* AppViewModel.swift */,
 				2F3D68D82E1D4210005148D9 /* QuotesViewModel.swift */,
+				042B0C9D2E227F3E00B4A017 /* SearchViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -169,6 +177,7 @@
 				2F3D68DD2E1D4210005148D9 /* Common */,
 				2F3D68DE2E1D4210005148D9 /* MainListView.swift */,
 				2F3D68DF2E1D4210005148D9 /* TickerListRowView.swift */,
+				042B0C9B2E227F2F00B4A017 /* SearchView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -358,13 +367,16 @@
 			files = (
 				2F3D68E42E1D4210005148D9 /* TradeUpApp.swift in Sources */,
 				2F3D68E52E1D4210005148D9 /* Quote+Extensions.swift in Sources */,
+				042B0C9E2E227F3E00B4A017 /* SearchViewModel.swift in Sources */,
 				2F3D68E62E1D4210005148D9 /* Stubs.swift in Sources */,
 				2F3D68E72E1D4210005148D9 /* TickerListRowData.swift in Sources */,
+				042B0C9A2E227E8A00B4A017 /* FetchPhase.swift in Sources */,
 				2F3D68E82E1D4210005148D9 /* Utils.swift in Sources */,
 				2F3D68E92E1D4210005148D9 /* AppViewModel.swift in Sources */,
 				2F3D68EA2E1D4210005148D9 /* QuotesViewModel.swift in Sources */,
 				2F3D68EB2E1D4210005148D9 /* EmptyStateView.swift in Sources */,
 				2F3D68EC2E1D4210005148D9 /* ErrorStateView.swift in Sources */,
+				042B0C9C2E227F2F00B4A017 /* SearchView.swift in Sources */,
 				2F3D68ED2E1D4210005148D9 /* LoadingStateView.swift in Sources */,
 				2F3D68EE2E1D4210005148D9 /* MainListView.swift in Sources */,
 				2F3D68EF2E1D4210005148D9 /* TickerListRowView.swift in Sources */,

--- a/TradeUp/TradeUp/App/TradeUpApp.swift
+++ b/TradeUp/TradeUp/App/TradeUpApp.swift
@@ -11,21 +11,14 @@ import StocksAPI
 @main
 struct TradeUpApp: App {
     
-    let stocksAPI = StocksAPI()
+    @StateObject var appVM = AppViewModel()
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .onAppear {
-                    Task {
-                        do {
-                            let quotes = try await stocksAPI.quoteService.getQuotes(symbols: ["AAPL"])
-                            print(quotes)
-                        } catch {
-                            print(error.localizedDescription)
-                        }
-                    }
-                }
+            NavigationStack {
+                MainListView()
+            }
+            .environmentObject(appVM)
         }
     }
 }

--- a/TradeUp/TradeUp/Models/FetchPhase.swift
+++ b/TradeUp/TradeUp/Models/FetchPhase.swift
@@ -1,0 +1,31 @@
+//
+//  FetchPhase.swift
+//  TradeUp
+//
+//  Created by MAC on 7/12/25.
+//
+
+import Foundation
+
+enum FetchPhase<V> {
+    
+    case initial
+    case fetching
+    case success(V)
+    case failure(Error)
+    case empty
+    
+    var value: V? {
+        if case .success(let v) = self {
+            return v
+        }
+        return nil
+    }
+    
+    var error: Error? {
+        if case .failure(let error) = self {
+            return error
+        }
+        return nil
+    }
+}

--- a/TradeUp/TradeUp/ViewModels/AppViewModel.swift
+++ b/TradeUp/TradeUp/ViewModels/AppViewModel.swift
@@ -13,5 +13,29 @@ import StocksAPI
 class AppViewModel: ObservableObject {
     
     @Published var tickers: [Ticker] = []
+    var titleText = "TradeUp"
+    @Published var subtitleText: String
+    var emptyTickersText = "Search & add symbol to see stock quotes"
+    var attributionText = "Powered by Yahoo! finance API"
     
+    private let subtitleDateFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "ko_KR") // 한국어 로케일 설정
+        df.dateFormat = "M월 d일 (E)" // 예: 7월 12일 (금)
+        return df
+    }()
+    
+    init() {
+        self.subtitleText = subtitleDateFormatter.string(from: Date())
+    }
+    
+    func removeTickers(atOffsets offsets: IndexSet) {
+        tickers.remove(atOffsets: offsets)
+    }
+    
+    func openYahooFinance() {
+        let url = URL(string: "https://finance.yahoo.com")!
+        guard UIApplication.shared.canOpenURL(url) else { return }
+        UIApplication.shared.open(url)
+    }
 }

--- a/TradeUp/TradeUp/ViewModels/AppViewModel.swift
+++ b/TradeUp/TradeUp/ViewModels/AppViewModel.swift
@@ -29,6 +29,27 @@ class AppViewModel: ObservableObject {
         self.subtitleText = subtitleDateFormatter.string(from: Date())
     }
     
+    func isAddedToMyTickers(ticker: Ticker) -> Bool {
+        tickers.first { $0.symbol == ticker.symbol } != nil
+    }
+    
+    func toggleTicker(_ ticker: Ticker) {
+        if isAddedToMyTickers(ticker: ticker) {
+            removeFromMyTickers(ticker: ticker)
+        } else {
+            addToMyTickers(ticker: ticker)
+        }
+    }
+    
+    private func addToMyTickers(ticker: Ticker) {
+        tickers.append(ticker)
+    }
+    
+    private func removeFromMyTickers(ticker: Ticker) {
+        guard let index = tickers.firstIndex(where: { $0.symbol == ticker.symbol }) else { return }
+        tickers.remove(at: index)
+    }
+    
     func removeTickers(atOffsets offsets: IndexSet) {
         tickers.remove(atOffsets: offsets)
     }

--- a/TradeUp/TradeUp/ViewModels/SearchViewModel.swift
+++ b/TradeUp/TradeUp/ViewModels/SearchViewModel.swift
@@ -1,0 +1,37 @@
+//
+//  SearchViewModel.swift
+//  TradeUp
+//
+//  Created by MAC on 7/12/25.
+//
+
+import SwiftUI
+import Combine
+import StocksAPI
+
+@MainActor
+class SearchViewModel: ObservableObject {
+
+    @Published var query: String = ""
+    @Published var phase: FetchPhase<[Ticker]> = .initial
+    
+    private var trimmedQuery: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    
+    var tickers: [Ticker] { phase.value ?? [] }
+    var error: Error? { phase.error }
+    var isSearching: Bool { !trimmedQuery.isEmpty }
+    
+    var emptyListText: String {
+        "Symbols not found for\n\"\(query)\""
+    }
+    
+    private var cancellables = Set<AnyCancellable>()
+    private let stocksAPI: StocksAPI
+    
+    init(query: String = "", stocksAPI: StocksAPI = StocksAPI()) {
+        self.query = query
+        self.stocksAPI = stocksAPI
+    }
+}

--- a/TradeUp/TradeUp/Views/MainListView.swift
+++ b/TradeUp/TradeUp/Views/MainListView.swift
@@ -12,6 +12,7 @@ struct MainListView: View {
     
     @EnvironmentObject var appVM: AppViewModel
     @StateObject var quotesVM = QuotesViewModel()
+    @StateObject var searchVM = SearchViewModel()
     
     var body: some View {
         tickerListView
@@ -21,6 +22,7 @@ struct MainListView: View {
                 titleToolbar
                 attributionToolbar
             }
+            .searchable(text: $searchVM.query)
     }
     
     private var tickerListView: some View {
@@ -43,6 +45,10 @@ struct MainListView: View {
     private var overlayView: some View {
         if appVM.tickers.isEmpty {
             EmptyStateView(text: appVM.emptyTickersText)
+        }
+        
+        if searchVM.isSearching {
+            SearchView(searchVM: searchVM)
         }
     }
     
@@ -93,16 +99,22 @@ struct MainListView_Previews: PreviewProvider {
         return vm
     }()
     
+    static var searchVM: SearchViewModel = {
+        var vm = SearchViewModel()
+        vm.phase = .success(Ticker.stubs )
+        return vm
+    }()
+    
     static var previews: some View {
         Group {
             NavigationStack {
-                MainListView(quotesVM: quotesVM)
+                MainListView(quotesVM: quotesVM, searchVM: searchVM)
             }
             .environmentObject(appVM)
             .previewDisplayName("With Tickers")
             
             NavigationStack {
-                MainListView(quotesVM: quotesVM)
+                MainListView(quotesVM: quotesVM, searchVM: searchVM)
             }
             .environmentObject(emptyAppVM)
             .previewDisplayName("With Empty Tickers")

--- a/TradeUp/TradeUp/Views/MainListView.swift
+++ b/TradeUp/TradeUp/Views/MainListView.swift
@@ -6,13 +6,106 @@
 //
 
 import SwiftUI
+import StocksAPI
 
 struct MainListView: View {
+    
+    @EnvironmentObject var appVM: AppViewModel
+    @StateObject var quotesVM = QuotesViewModel()
+    
     var body: some View {
-        Text("Hello, World!")
+        tickerListView
+            .listStyle(.plain)
+            .overlay { overlayView }
+            .toolbar {
+                titleToolbar
+                attributionToolbar
+            }
+    }
+    
+    private var tickerListView: some View {
+        List {
+            ForEach(appVM.tickers) { ticker in
+                TickerListRowView(
+                    data: .init(
+                        symbol: ticker.symbol,
+                        name: ticker.shortname,
+                        price: quotesVM.priceForTicker(ticker),
+                        type: .main))
+                .contentShape(Rectangle()) // 역할이 뭘까
+                .onTapGesture { }
+            }
+            .onDelete { appVM.removeTickers(atOffsets: $0) }
+        }
+    }
+    
+    @ViewBuilder
+    private var overlayView: some View {
+        if appVM.tickers.isEmpty {
+            EmptyStateView(text: appVM.emptyTickersText)
+        }
+    }
+    
+    private var titleToolbar: some ToolbarContent {
+        ToolbarItem(placement: .navigationBarLeading) {
+            VStack(alignment: .leading, spacing: -4) {
+                Text(appVM.titleText)
+                Text(appVM.subtitleText).foregroundColor(Color(uiColor: .secondaryLabel))
+            }.font(.title2.weight(.heavy))
+                .padding(.bottom)
+        }
+    }
+    
+    private var attributionToolbar: some ToolbarContent {
+        ToolbarItem(placement: .bottomBar) {
+            HStack {
+                Button {
+                    appVM.openYahooFinance()
+                } label: {
+                    Text(appVM.attributionText)
+                        .font(.caption.weight(.heavy))
+                        .foregroundColor(Color(uiColor: .secondaryLabel))
+                }
+                .buttonStyle(.plain)
+                Spacer()
+            }
+        }
     }
 }
 
-#Preview {
-    MainListView()
+struct MainListView_Previews: PreviewProvider {
+    
+    @StateObject static var appVM: AppViewModel = {
+        let vm = AppViewModel()
+        vm.tickers = Ticker.stubs
+        return vm
+    }()
+    
+    @StateObject static var emptyAppVM: AppViewModel = {
+        let vm = AppViewModel()
+        vm.tickers = []
+        return vm
+    }()
+    
+    static var quotesVM: QuotesViewModel = {
+        var vm = QuotesViewModel()
+        vm.quotesDict = Quote.stubsDict
+        return vm
+    }()
+    
+    static var previews: some View {
+        Group {
+            NavigationStack {
+                MainListView(quotesVM: quotesVM)
+            }
+            .environmentObject(appVM)
+            .previewDisplayName("With Tickers")
+            
+            NavigationStack {
+                MainListView(quotesVM: quotesVM)
+            }
+            .environmentObject(emptyAppVM)
+            .previewDisplayName("With Empty Tickers")
+        }
+    }
 }

--- a/TradeUp/TradeUp/Views/SearchView.swift
+++ b/TradeUp/TradeUp/Views/SearchView.swift
@@ -1,0 +1,124 @@
+//
+//  SearchView.swift
+//  TradeUp
+//
+//  Created by MAC on 7/12/25.
+//
+
+import SwiftUI
+import StocksAPI
+
+@MainActor
+struct SearchView: View {
+    
+    @EnvironmentObject var appVM: AppViewModel
+    @StateObject var quotesVM = QuotesViewModel()
+    @ObservedObject var searchVM: SearchViewModel
+    
+    var body: some View {
+        List(searchVM.tickers) { ticker in
+            TickerListRowView(
+                data: .init(
+                    symbol: ticker.symbol,
+                    name: ticker.shortname,
+                    price: quotesVM.priceForTicker(ticker),
+                    type: .search(
+                        isSaved: appVM.isAddedToMyTickers(ticker: ticker),
+                        onButtonTapped: {
+                            Task { @MainActor in
+                                appVM.toggleTicker(ticker)
+                            }
+                        }
+                    )
+                )
+            )
+            .contentShape(Rectangle())
+            .onTapGesture {}
+        }
+        .listStyle(.plain)
+        .overlay { listSearchOverlay }
+    }
+    
+    @ViewBuilder
+    private var listSearchOverlay: some View {
+        switch searchVM.phase {
+        case .failure(let error):
+            ErrorStateView(error: error.localizedDescription){}
+        case .empty:
+            EmptyStateView(text: searchVM.emptyListText)
+        case .fetching:
+            LoadingStateView()
+        default: EmptyView()
+        }
+    }
+}
+
+struct SearchView_Previews: PreviewProvider {
+    
+    @StateObject static var stubbedSearchVM: SearchViewModel = {
+        var vm = SearchViewModel()
+        vm.phase = .success(Ticker.stubs)
+        return vm
+    }()
+    
+    @StateObject static var emptySearchVM: SearchViewModel = {
+        var vm = SearchViewModel()
+        vm.query = "Theranos"
+        vm.phase = .empty
+        return vm
+    }()
+    
+    @StateObject static var loadingSearchVM: SearchViewModel = {
+        var vm = SearchViewModel()
+        vm.phase = .fetching
+        return vm
+    }()
+    
+    @StateObject static var errorSearchVM: SearchViewModel = {
+        var vm = SearchViewModel()
+        vm.phase = .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "An Error has been occurred"]))
+        return vm
+    }()
+    
+    @StateObject static var appVM: AppViewModel = {
+        let vm = AppViewModel()
+        vm.tickers = Array(Ticker.stubs.prefix(upTo:2)) //0,1 만 가져와서 체크되도록
+        return vm
+    }()
+    
+    static var quotesVM: QuotesViewModel = {
+        var vm = QuotesViewModel()
+        vm.quotesDict = Quote.stubsDict
+        return vm
+    }()
+    
+    static var previews: some View {
+        Group {
+            NavigationStack {
+                SearchView(quotesVM: quotesVM, searchVM: stubbedSearchVM)
+            }
+            .searchable(text: $stubbedSearchVM.query) // 이거 뭐지
+            .previewDisplayName("Results")
+            
+            NavigationStack {
+                SearchView(quotesVM: quotesVM, searchVM: emptySearchVM)
+            }
+            .searchable(text: $emptySearchVM.query)
+            .previewDisplayName("Empty Results")
+            
+            NavigationStack {
+                SearchView(quotesVM: quotesVM, searchVM: loadingSearchVM)
+            }
+            .searchable(text: $loadingSearchVM.query)
+            .previewDisplayName("Loading State")
+            
+            NavigationStack {
+                SearchView(quotesVM: quotesVM, searchVM: errorSearchVM)
+            }
+            .searchable(text: $errorSearchVM.query)
+            .previewDisplayName("Error State")
+            
+            
+        }.environmentObject(appVM)
+    }
+}


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
메인 주식 리스트 뷰와 검색뷰를 구현 하였습니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- Stock List View 구현
- 앱 전체에서 사용할 비동기 작업의 상태 타입 정의
- SearchViewModel, SearchView 구현

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/4ebd0913-34bc-406e-8ed5-1e6919e5d818" width ="250"> | <img src = "https://github.com/user-attachments/assets/4ebd0913-34bc-406e-8ed5-1e6919e5d818" width ="250"> | <img src = "https://github.com/user-attachments/assets/4ebd0913-34bc-406e-8ed5-1e6919e5d818" width ="250"> |






## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`AppViewModel`
- 변수와, 메서드 기능 정리
홈 화면에서 주식 종목 리스트를 관리하는 ViewModel입니다. Yahoo Finance API를 기반으로 관심 종목을 추가/삭제하고, 날짜 표시 및 외부 링크 열기 기능을 제공합니다.
<hr>
주요 변수

변수명 | 설명
-- | --
@Published var tickers: [Ticker] | 관심 종목 배열. UI 바인딩됨.
@Published var subtitleText | 오늘 날짜를 포맷팅한 텍스트. 앱 실행 시 초기화됨.
var titleText | 앱 상단 타이틀 ("TradeUp").
var emptyTickersText | 티커가 없을 때의 안내 문구.
var attributionText | 데이터 출처 문구 ("Powered by Yahoo! finance API").
private let subtitleDateFormatter | 날짜 포맷터. "7월 17일 (수)" 형식으로 설정.


<hr>
주요 메서드

- `isAddedToMyTickers(ticker:)`
    
    → 해당 티커가 `tickers` 배열에 이미 포함되어 있는지 확인
    
- `toggleTicker(_:)`
    
    → 종목이 이미 있다면 삭제, 없으면 추가
    
- `addToMyTickers(ticker:)`
    
    → 관심 종목 배열에 추가 (내부 전용)
    
- `removeFromMyTickers(ticker:)`
    
    → 관심 종목 배열에서 제거 (내부 전용)
    
- `removeTickers(atOffsets:)`
    
    → SwiftUI `List`의 삭제 기능과 연결됨
    
- `openYahooFinance()`

<h3>참고</h3>
<ul>
<li>
<p><code>@MainActor</code>는 ViewModel의 모든 메서드와 프로퍼티 접근이 <strong>항상 메인 스레드에서 실행되도록 보장</strong>합니다.</p>
<p>UI 업데이트를 동반하는 <code>@Published</code>와 함께 안전하게 사용됩니다.</p>
</li>
</ul>


`FetchPhase`
- 비동기 작업의 상태 타입 정의
발생 할 수 있는 상황에 대해서 case를 정의하고 이에 따른 View 대응 및 로직 대응을 할 것임
```swift
enum FetchPhase<V> {
    
    case initial  // 아직 요청을 시작하지 않은 초기 상태
    case fetching // 데이터를 불러오는 중 (로딩 상태)
    case success(V) // 데이터를 성공적으로 받아온 상태 (V는 받아온 데이터)
    case failure(Error)  // 에러가 발생한 상태 (Error는 에러 정보)
    case empty // 요청은 성공했지만 결과 데이터가 비어있는 상태
    
    var value: V? {
        if case .success(let v) = self {
            return v
        }
        return nil
    }
    
    var error: Error? {
        if case .failure(let error) = self {
            return error
        }
        return nil
    }
}
```

`SearchViewModel`
- 프로퍼티 정리 

프로퍼티 | 타입 | 설명
-- | -- | --
@Published var query | String | 사용자가 검색창에 입력한 문자열. SwiftUI와 바인딩되어 실시간 반영됩니다.
@Published var phase | FetchPhase<[Ticker]> | 비동기 검색 상태 (초기, 로딩, 성공, 실패, 결과 없음 등)를 나타냅니다.
private var trimmedQuery | String | query에서 앞뒤 공백을 제거한 문자열. 검색 실행 시 사용.
var tickers | [Ticker] | 현재 phase가 .success일 경우 검색 결과 리스트. 그 외엔 빈 배열 반환.
var error | Error? | 현재 phase가 .failure일 경우 에러 반환. 그 외엔 nil.
var isSearching | Bool | 입력된 쿼리가 비어 있지 않으면 true. 검색 중임을 나타내는 조건으로 사용.
var emptyListText | String | 검색 결과가 없을 때 사용자에게 보여줄 텍스트 메시지. 입력된 쿼리를 포함함.
private var cancellables | Set<AnyCancellable> | Combine 구독을 담는 저장소. 메모리 누수 방지용.
private let stocksAPI | StocksAPI | 실제로 주식 종목을 검색하는 API 클래스의 인스턴스. 의존성 주입으로 테스트 가능.


'SearchView'
– 비동기 상태별 Preview 정리

FetchPhase 상태 | UI 구성 | 사용된 뷰 | 프리뷰 이름 (.previewDisplayName)
-- | -- | -- | --
.initial or .success([Ticker]) | 정상 결과 리스트 | TickerListRowView 목록 | "Results"
.empty | 결과 없음 메시지 | EmptyStateView | "Empty Results"
.fetching | 로딩 스피너 | LoadingStateView | "Loading State"
.failure(Error) | 에러 메시지 뷰 | ErrorStateView | "Error State"

<h3> Preview에 사용된 ViewModel 상태 예시</h3>

```swift
@StateObject static var stubbedSearchVM: SearchViewModel = {
    var vm = SearchViewModel()
    vm.phase = .success(Ticker.stubs)
    return vm
}()
```

상태 | 설명
-- | --
stubbedSearchVM | 정상적인 결과가 있는 상태 (예: 종목 리스트 표시)
emptySearchVM | 검색 결과가 비어 있음 (.empty)
loadingSearchVM | 데이터를 불러오는 중 (.fetching)
errorSearchVM | 에러 발생 (.failure(Error))
<img width="569" height="634" alt="image" src="https://github.com/user-attachments/assets/ac199f18-794a-4e5b-823c-a066e3dd26af" />


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #3 
