### PR TITLE
Feat/#6 connect stock api

### DIFF
--- a/TradeUp/TradeUp.xcodeproj/project.pbxproj
+++ b/TradeUp/TradeUp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		042B0C9A2E227E8A00B4A017 /* FetchPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042B0C992E227E8A00B4A017 /* FetchPhase.swift */; };
 		042B0C9C2E227F2F00B4A017 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042B0C9B2E227F2F00B4A017 /* SearchView.swift */; };
 		042B0C9E2E227F3E00B4A017 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042B0C9D2E227F3E00B4A017 /* SearchViewModel.swift */; };
+		04D8F9E12E28E5CE00DE046E /* StockRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D8F9E02E28E5CE00DE046E /* StockRepository.swift */; };
+		04D8F9E32E28F24500DE046E /* MockStocksAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */; };
 		2F3D68E42E1D4210005148D9 /* TradeUpApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */; };
 		2F3D68E52E1D4210005148D9 /* Quote+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68CE2E1D4210005148D9 /* Quote+Extensions.swift */; };
 		2F3D68E62E1D4210005148D9 /* Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68D02E1D4210005148D9 /* Stubs.swift */; };
@@ -49,6 +51,8 @@
 		042B0C992E227E8A00B4A017 /* FetchPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPhase.swift; sourceTree = "<group>"; };
 		042B0C9B2E227F2F00B4A017 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		042B0C9D2E227F3E00B4A017 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		04D8F9E02E28E5CE00DE046E /* StockRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockRepository.swift; sourceTree = "<group>"; };
+		04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStocksAPI.swift; sourceTree = "<group>"; };
 		2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeUpApp.swift; sourceTree = "<group>"; };
 		2F3D68CE2E1D4210005148D9 /* Quote+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quote+Extensions.swift"; sourceTree = "<group>"; };
 		2F3D68D02E1D4210005148D9 /* Stubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stubs.swift; sourceTree = "<group>"; };
@@ -109,6 +113,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		04D8F9DF2E28E5BD00DE046E /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				04D8F9E02E28E5CE00DE046E /* StockRepository.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		2F3D68CD2E1D4210005148D9 /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -129,6 +141,7 @@
 			isa = PBXGroup;
 			children = (
 				2F3D68D02E1D4210005148D9 /* Stubs.swift */,
+				04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */,
 			);
 			path = "Mocks & Stubs";
 			sourceTree = "<group>";
@@ -185,6 +198,7 @@
 		2F3D68E32E1D4210005148D9 /* TradeUp */ = {
 			isa = PBXGroup;
 			children = (
+				04D8F9DF2E28E5BD00DE046E /* Services */,
 				2F3D68CD2E1D4210005148D9 /* App */,
 				2F3D68CF2E1D4210005148D9 /* Extensions */,
 				2F3D68D12E1D4210005148D9 /* Mocks & Stubs */,
@@ -376,8 +390,10 @@
 				2F3D68EA2E1D4210005148D9 /* QuotesViewModel.swift in Sources */,
 				2F3D68EB2E1D4210005148D9 /* EmptyStateView.swift in Sources */,
 				2F3D68EC2E1D4210005148D9 /* ErrorStateView.swift in Sources */,
+				04D8F9E32E28F24500DE046E /* MockStocksAPI.swift in Sources */,
 				042B0C9C2E227F2F00B4A017 /* SearchView.swift in Sources */,
 				2F3D68ED2E1D4210005148D9 /* LoadingStateView.swift in Sources */,
+				04D8F9E12E28E5CE00DE046E /* StockRepository.swift in Sources */,
 				2F3D68EE2E1D4210005148D9 /* MainListView.swift in Sources */,
 				2F3D68EF2E1D4210005148D9 /* TickerListRowView.swift in Sources */,
 				2F3D68F02E1D4210005148D9 /* ContentView.swift in Sources */,

--- a/TradeUp/TradeUp.xcodeproj/project.pbxproj
+++ b/TradeUp/TradeUp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		042B0C9A2E227E8A00B4A017 /* FetchPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042B0C992E227E8A00B4A017 /* FetchPhase.swift */; };
 		042B0C9C2E227F2F00B4A017 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042B0C9B2E227F2F00B4A017 /* SearchView.swift */; };
 		042B0C9E2E227F3E00B4A017 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042B0C9D2E227F3E00B4A017 /* SearchViewModel.swift */; };
+		048328692E3111B1006204CF /* TickerListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048328682E3111B1006204CF /* TickerListRepository.swift */; };
+		0483286B2E311640006204CF /* MockTickerListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0483286A2E311640006204CF /* MockTickerListRepository.swift */; };
 		04D8F9E12E28E5CE00DE046E /* StockRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D8F9E02E28E5CE00DE046E /* StockRepository.swift */; };
 		04D8F9E32E28F24500DE046E /* MockStocksAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */; };
 		2F3D68E42E1D4210005148D9 /* TradeUpApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */; };
@@ -51,6 +53,8 @@
 		042B0C992E227E8A00B4A017 /* FetchPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPhase.swift; sourceTree = "<group>"; };
 		042B0C9B2E227F2F00B4A017 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		042B0C9D2E227F3E00B4A017 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		048328682E3111B1006204CF /* TickerListRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerListRepository.swift; sourceTree = "<group>"; };
+		0483286A2E311640006204CF /* MockTickerListRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTickerListRepository.swift; sourceTree = "<group>"; };
 		04D8F9E02E28E5CE00DE046E /* StockRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockRepository.swift; sourceTree = "<group>"; };
 		04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStocksAPI.swift; sourceTree = "<group>"; };
 		2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeUpApp.swift; sourceTree = "<group>"; };
@@ -117,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				04D8F9E02E28E5CE00DE046E /* StockRepository.swift */,
+				048328682E3111B1006204CF /* TickerListRepository.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -142,6 +147,7 @@
 			children = (
 				2F3D68D02E1D4210005148D9 /* Stubs.swift */,
 				04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */,
+				0483286A2E311640006204CF /* MockTickerListRepository.swift */,
 			);
 			path = "Mocks & Stubs";
 			sourceTree = "<group>";
@@ -395,6 +401,8 @@
 				2F3D68ED2E1D4210005148D9 /* LoadingStateView.swift in Sources */,
 				04D8F9E12E28E5CE00DE046E /* StockRepository.swift in Sources */,
 				2F3D68EE2E1D4210005148D9 /* MainListView.swift in Sources */,
+				048328692E3111B1006204CF /* TickerListRepository.swift in Sources */,
+				0483286B2E311640006204CF /* MockTickerListRepository.swift in Sources */,
 				2F3D68EF2E1D4210005148D9 /* TickerListRowView.swift in Sources */,
 				2F3D68F02E1D4210005148D9 /* ContentView.swift in Sources */,
 			);

--- a/TradeUp/TradeUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TradeUp/TradeUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/jeonguk29/YahooStocksKit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "e5550595e144139068bd3edc76a5554f012eea41"
+        "revision" : "796448bb0e71593a867e08463a614d0f7d628a74"
       }
     }
   ],

--- a/TradeUp/TradeUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TradeUp/TradeUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/jeonguk29/YahooStocksKit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "796448bb0e71593a867e08463a614d0f7d628a74"
+        "revision" : "e2350743c691130221ebd0533ce9b60ffcb2c5bc"
       }
     }
   ],

--- a/TradeUp/TradeUp/Mocks & Stubs/MockStocksAPI.swift
+++ b/TradeUp/TradeUp/Mocks & Stubs/MockStocksAPI.swift
@@ -1,0 +1,25 @@
+//
+//  MockStocksAPI.swift
+//  TradeUp
+//
+//  Created by MAC on 7/17/25.
+//
+
+import Foundation
+import StocksAPI
+
+#if DEBUG
+struct MockStocksAPI: StockRepository {
+    
+    var stubbedSearchTickersCallback: (() async throws -> [Ticker])!
+    func searchTickers(query: String, isEquityTypeOnly: Bool) async throws -> [Ticker] {
+        try await stubbedSearchTickersCallback()
+    }
+    
+    var stubbedFetchQuotesCallback: (() async throws -> [Quote])!
+    func fetchQuotes(symbols: String) async throws -> [Quote] {
+        try await stubbedFetchQuotesCallback()
+    }
+    
+}
+#endif

--- a/TradeUp/TradeUp/Mocks & Stubs/MockTickerListRepository.swift
+++ b/TradeUp/TradeUp/Mocks & Stubs/MockTickerListRepository.swift
@@ -1,0 +1,23 @@
+//
+//  MockTickerListRepository.swift
+//  TradeUp
+//
+//  Created by MAC on 7/23/25.
+//
+
+import Foundation
+import StocksAPI
+
+#if DEBUG
+struct MockTickerListRepository: TickerListRepository {
+    
+    var stubbedLoad: (() async throws -> [Ticker])!
+    
+    func load() async throws -> [Ticker] {
+        try await stubbedLoad()
+    }
+    
+    func save(_ current: [Ticker]) async throws {}
+    
+}
+#endif

--- a/TradeUp/TradeUp/Services/StockRepository.swift
+++ b/TradeUp/TradeUp/Services/StockRepository.swift
@@ -1,0 +1,16 @@
+//
+//  StocksAPI.swift
+//  TradeUp
+//
+//  Created by MAC on 7/17/25.
+//
+
+import Foundation
+import StocksAPI
+
+protocol StockRepository {
+    func searchTickers(query: String, isEquityTypeOnly: Bool) async throws -> [Ticker]
+    func fetchQuotes(symbols: String) async throws -> [Quote]
+}
+
+extension StocksAPI: StockRepository {}

--- a/TradeUp/TradeUp/Services/TickerListRepository.swift
+++ b/TradeUp/TradeUp/Services/TickerListRepository.swift
@@ -1,0 +1,50 @@
+//
+//  TickerListRepository.swift
+//  TradeUp
+//
+//  Created by MAC on 7/23/25.
+//
+
+import Foundation
+import StocksAPI
+
+protocol TickerListRepository {
+    func save(_ current: [Ticker]) async throws
+    func load() async throws -> [Ticker]
+}
+
+class TickerPlistRepository: TickerListRepository {
+    
+    private var saved: [Ticker]?
+    private let filename: String
+    
+    private var url: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appending(component: "\(filename).plist")
+    }
+    
+    init(filename: String = "my_tickers") {
+        self.filename = filename
+    }
+    
+    func save(_ current: [Ticker]) throws {
+        if let saved, saved == current { // 지금 저장 되어 있는 것과 같은지 확인
+            return
+        }
+        
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        let data = try encoder.encode(current)
+        try data.write(to: url, options: [.atomic])
+        self.saved = current
+    }
+    
+    
+    func load() throws -> [Ticker] {
+        let data = try Data(contentsOf: url)
+        let current = try PropertyListDecoder().decode([Ticker].self, from: data)
+        self.saved = current
+        return current
+    }
+    
+}

--- a/TradeUp/TradeUp/ViewModels/QuotesViewModel.swift
+++ b/TradeUp/TradeUp/ViewModels/QuotesViewModel.swift
@@ -13,6 +13,24 @@ import StocksAPI
 class QuotesViewModel: ObservableObject {
     
     @Published var quotesDict: [String: Quote] = [:]
+    private let stocksAPI: StockRepository
+    
+    init(stocksAPI: StockRepository = StocksAPI()) {
+        self.stocksAPI = stocksAPI
+    }
+    
+    func fetchQuotes(tickers: [Ticker]) async {
+        guard !tickers.isEmpty else { return }
+        do {
+            let symbols = tickers.map { $0.symbol }.joined(separator: ",")
+            let quotes = try await stocksAPI.fetchQuotes(symbols: symbols)
+            var dict = [String: Quote]()
+            quotes.forEach { dict[$0.symbol ?? ""] = $0 }
+            self.quotesDict = dict
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
     
     func priceForTicker(_ ticker: Ticker) -> PriceChange? {
         guard let quote = quotesDict[ticker.symbol],

--- a/TradeUp/TradeUp/ViewModels/SearchViewModel.swift
+++ b/TradeUp/TradeUp/ViewModels/SearchViewModel.swift
@@ -11,7 +11,7 @@ import StocksAPI
 
 @MainActor
 class SearchViewModel: ObservableObject {
-
+    
     @Published var query: String = ""
     @Published var phase: FetchPhase<[Ticker]> = .initial
     
@@ -28,10 +28,45 @@ class SearchViewModel: ObservableObject {
     }
     
     private var cancellables = Set<AnyCancellable>()
-    private let stocksAPI: StocksAPI
+    private let stocksAPI: StockRepository // 프로토콜화
     
-    init(query: String = "", stocksAPI: StocksAPI = StocksAPI()) {
+    init(query: String = "", stocksAPI: StockRepository = StocksAPI()) {
         self.query = query
         self.stocksAPI = stocksAPI
+        startObserving()
+     }
+     
+     private func startObserving() {
+         $query // 사용자 입역 쿼리를 구독해서 변경이 생기는것을 관찰
+             .debounce(for: 0.25, scheduler: DispatchQueue.main)
+             .sink { _ in
+                 Task { [weak self] in await self?.searchTickers() }
+             }
+             .store(in: &cancellables)
+         
+         $query
+             .filter { $0.isEmpty }
+             .sink { [weak self] _ in self?.phase = .initial }
+             .store(in: &cancellables)
+     }
+    
+    func searchTickers() async {
+        let searchQuery = trimmedQuery
+        guard !searchQuery.isEmpty else { return }
+        phase = .fetching
+        
+        do {
+            let tickers = try await stocksAPI.searchTickers(query: searchQuery, isEquityTypeOnly: true)
+            if searchQuery != trimmedQuery { return }
+            if tickers.isEmpty {
+                phase = .empty
+            } else {
+                phase = .success(tickers)
+            }
+        } catch {
+            if searchQuery != trimmedQuery { return }
+            print(error.localizedDescription)
+            phase = .failure(error)
+        }
     }
 }

--- a/TradeUp/TradeUp/Views/MainListView.swift
+++ b/TradeUp/TradeUp/Views/MainListView.swift
@@ -96,15 +96,15 @@ struct MainListView_Previews: PreviewProvider {
     }()
     
     static var quotesVM: QuotesViewModel = {
-        var vm = QuotesViewModel()
-        vm.quotesDict = Quote.stubsDict
-        return vm
+        var mock = MockStocksAPI()
+        mock.stubbedFetchQuotesCallback = { Quote.stubs }
+        return QuotesViewModel(stocksAPI: mock)
     }()
     
     static var searchVM: SearchViewModel = {
-        var vm = SearchViewModel()
-        vm.phase = .success(Ticker.stubs )
-        return vm
+        var mock = MockStocksAPI()
+        mock.stubbedSearchTickersCallback = { Ticker.stubs }
+        return SearchViewModel(stocksAPI: mock)
     }()
     
     static var previews: some View {

--- a/TradeUp/TradeUp/Views/MainListView.swift
+++ b/TradeUp/TradeUp/Views/MainListView.swift
@@ -23,6 +23,8 @@ struct MainListView: View {
                 attributionToolbar
             }
             .searchable(text: $searchVM.query)
+            .refreshable { await quotesVM.fetchQuotes(tickers: appVM.tickers) }
+            .task(id: appVM.tickers) { await quotesVM.fetchQuotes(tickers: appVM.tickers) }
     }
     
     private var tickerListView: some View {
@@ -34,7 +36,7 @@ struct MainListView: View {
                         name: ticker.shortname,
                         price: quotesVM.priceForTicker(ticker),
                         type: .main))
-                .contentShape(Rectangle()) // 역할이 뭘까
+                .contentShape(Rectangle())
                 .onTapGesture { }
             }
             .onDelete { appVM.removeTickers(atOffsets: $0) }

--- a/TradeUp/TradeUp/Views/MainListView.swift
+++ b/TradeUp/TradeUp/Views/MainListView.swift
@@ -84,16 +84,17 @@ struct MainListView: View {
 struct MainListView_Previews: PreviewProvider {
     
     @StateObject static var appVM: AppViewModel = {
-        let vm = AppViewModel()
-        vm.tickers = Ticker.stubs
-        return vm
+        var mock = MockTickerListRepository()
+        mock.stubbedLoad = { Ticker.stubs }
+        return AppViewModel(repository: mock)
     }()
     
     @StateObject static var emptyAppVM: AppViewModel = {
-        let vm = AppViewModel()
-        vm.tickers = []
-        return vm
+        var mock = MockTickerListRepository()
+        mock.stubbedLoad = { [] }
+        return AppViewModel(repository: mock)
     }()
+    
     
     static var quotesVM: QuotesViewModel = {
         var mock = MockStocksAPI()

--- a/TradeUp/TradeUp/Views/SearchView.swift
+++ b/TradeUp/TradeUp/Views/SearchView.swift
@@ -89,9 +89,9 @@ struct SearchView_Previews: PreviewProvider {
     }()
     
     @StateObject static var appVM: AppViewModel = {
-        let vm = AppViewModel()
-        vm.tickers = Array(Ticker.stubs.prefix(upTo:2)) 
-        return vm
+        var mock = MockTickerListRepository()
+        mock.stubbedLoad = { Array(Ticker.stubs.prefix(upTo: 2)) }
+        return AppViewModel(repository: mock)
     }()
     
     static var quotesVM: QuotesViewModel = {

--- a/TradeUp/TradeUp/Views/SearchView.swift
+++ b/TradeUp/TradeUp/Views/SearchView.swift
@@ -28,14 +28,17 @@ struct SearchView: View {
                             Task { @MainActor in
                                 appVM.toggleTicker(ticker)
                             }
-                        }
+                        } 
                     )
                 )
             )
-            .contentShape(Rectangle())
-            .onTapGesture {}
+            //.contentShape(Rectangle())
+            //.onTapGesture {}
         }
         .listStyle(.plain)
+        .refreshable { await quotesVM.fetchQuotes(tickers: searchVM.tickers) }
+        .task(id: searchVM.tickers) { await quotesVM.fetchQuotes(tickers: searchVM.tickers) }
+        // 티커 변경시 마다 새로고침
         .overlay { listSearchOverlay }
     }
     
@@ -43,7 +46,11 @@ struct SearchView: View {
     private var listSearchOverlay: some View {
         switch searchVM.phase {
         case .failure(let error):
-            ErrorStateView(error: error.localizedDescription){}
+            ErrorStateView(error: error.localizedDescription){
+                Task {
+                    await searchVM.searchTickers()
+                }
+            }
         case .empty:
             EmptyStateView(text: searchVM.emptyListText)
         case .fetching:

--- a/TradeUp/TradeUp/Views/SearchView.swift
+++ b/TradeUp/TradeUp/Views/SearchView.swift
@@ -28,7 +28,7 @@ struct SearchView: View {
                             Task { @MainActor in
                                 appVM.toggleTicker(ticker)
                             }
-                        } 
+                        }
                     )
                 )
             )
@@ -63,48 +63,50 @@ struct SearchView: View {
 struct SearchView_Previews: PreviewProvider {
     
     @StateObject static var stubbedSearchVM: SearchViewModel = {
-        var vm = SearchViewModel()
-        vm.phase = .success(Ticker.stubs)
-        return vm
+        var mock = MockStocksAPI()
+        mock.stubbedSearchTickersCallback = { Ticker.stubs }
+        return SearchViewModel(query: "Apple", stocksAPI: mock)
     }()
     
     @StateObject static var emptySearchVM: SearchViewModel = {
-        var vm = SearchViewModel()
-        vm.query = "Theranos"
-        vm.phase = .empty
-        return vm
+        var mock = MockStocksAPI()
+        mock.stubbedSearchTickersCallback = { [] }
+        return SearchViewModel(query: "Theranos", stocksAPI: mock)
     }()
     
     @StateObject static var loadingSearchVM: SearchViewModel = {
-        var vm = SearchViewModel()
-        vm.phase = .fetching
-        return vm
+        var mock = MockStocksAPI()
+        mock.stubbedSearchTickersCallback = {
+            await withCheckedContinuation { _ in }
+        }
+        return SearchViewModel(query: "Apple", stocksAPI: mock)
     }()
     
     @StateObject static var errorSearchVM: SearchViewModel = {
-        var vm = SearchViewModel()
-        vm.phase = .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "An Error has been occurred"]))
-        return vm
+        var mock = MockStocksAPI()
+        mock.stubbedSearchTickersCallback = { throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "An Error has been occured"]) }
+        return SearchViewModel(query: "Apple", stocksAPI: mock)
     }()
     
     @StateObject static var appVM: AppViewModel = {
         let vm = AppViewModel()
-        vm.tickers = Array(Ticker.stubs.prefix(upTo:2)) //0,1 만 가져와서 체크되도록
+        vm.tickers = Array(Ticker.stubs.prefix(upTo:2)) 
         return vm
     }()
     
     static var quotesVM: QuotesViewModel = {
-        var vm = QuotesViewModel()
-        vm.quotesDict = Quote.stubsDict
-        return vm
+        var mock = MockStocksAPI()
+        mock.stubbedFetchQuotesCallback = { Quote.stubs }
+        return QuotesViewModel(stocksAPI: mock)
     }()
+    
     
     static var previews: some View {
         Group {
             NavigationStack {
                 SearchView(quotesVM: quotesVM, searchVM: stubbedSearchVM)
             }
-            .searchable(text: $stubbedSearchVM.query) // 이거 뭐지
+            .searchable(text: $stubbedSearchVM.query) 
             .previewDisplayName("Results")
             
             NavigationStack {


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
의존성 주입 기반으로 StockRepository를 구현하여
실제 API와 Mock 객체를 유연하게 전환할 수 있도록 구조화했습니다.
또한, SearchViewModel, QuotesViewModel, MainListView의 비동기 흐름을
Combine + Swift Concurrency 방식으로 리팩토링하고,
사용자 관심 종목 데이터를 로컬 파일(plist)에 저장/불러오는 기능도 추가했습니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- StockRepository 프로토콜 도입
- StocksAPI 확장 → 실제 API 연결
- MockStocksAPI 구현 → Preview 및 테스트 대응
- SearchViewModel: Combine 기반 검색 흐름 구성  (@Published query 감지)
- QuotesViewModel: 종목별 quote 비동기 fetch 구현
- MainListView: .task(id:), .refreshable 활용하여 실시간 시세 갱신 흐름 구성
- TickerPlistRepository 구현 → 관심 종목 리스트를 plist 파일로 저장 및 불러오기 (이를 위해 StocksAPI 라이브러리 Ticker 모델에 Codable, Equatable 채택)

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->
실제 API와 테스트 환경(Mock)의 유연한 전환을 위해 DI 패턴을 명확히 적용했습니다.

검색 쿼리 처리는 Combine (@Published + debounce)과 async/await을 적절히 조합해 구조적 동시성을 유지하면서 깔끔한 흐름을 구현했습니다.

QuotesViewModel에서 quote 데이터는 딕셔너리로 정리하여 종목별 가격을 즉시 조회할 수 있게 구성했습니다.

앱을 껐다 켜도 관심 종목 정보를 유지할 수 있도록 파일 시스템 기반 .plist 저장 로직을 추가했습니다.


## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/5e28b5f2-550c-450c-99f2-5f6668ef90a2" width ="250"> | <img src = "https://github.com/user-attachments/assets/5e28b5f2-550c-450c-99f2-5f6668ef90a2" width ="250"> | <img src = "https://github.com/user-attachments/assets/5e28b5f2-550c-450c-99f2-5f6668ef90a2" width ="250"> |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
SearchViewModel의 Combine + async/await 구조에 대한 의견 환영합니다.
QuotesViewModel.fetchQuotes의 symbol-to-dictionary 구성 방식에서 성능 및 안정성 피드백 부탁드립니다.

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`의존성 주입 기반으로 StockRepository를 구현 내용`
```swift 
protocol StockRepository {
    func searchTickers(query: String, isEquityTypeOnly: Bool) async throws -> [Ticker]
    func fetchQuotes(symbols: String) async throws -> [Quote]
}

// 실제 구현체: StocksAPI 확장
extension StocksAPI: StockRepository {}
```

Mock 객체: ViewModel 및 프리뷰 적용
```swift 
#if DEBUG
struct MockStocksAPI: StockRepository {
    var stubbedSearchTickersCallback: (() async throws -> [Ticker])!
    var stubbedFetchQuotesCallback: (() async throws -> [Quote])!

    func searchTickers(query: String, isEquityTypeOnly: Bool) async throws -> [Ticker] {
        try await stubbedSearchTickersCallback()
    }

    func fetchQuotes(symbols: String) async throws -> [Quote] {
        try await stubbedFetchQuotesCallback()
    }
}
#endif


// ViewModel 적용 부분
@MainActor
class QuotesViewModel: ObservableObject {
    private let stocksAPI: StockRepository

    init(stocksAPI: StockRepository = StocksAPI()) {
        self.stocksAPI = stocksAPI
    }

    ...
}

// 프리뷰 적용
 static var quotesVM: QuotesViewModel = {
        var mock = MockStocksAPI()
        mock.stubbedFetchQuotesCallback = { Quote.stubs }
        return QuotesViewModel(stocksAPI: mock)
    }()
    
```


"Combine + @Published + Swift Concurrency (async/await) 조합"
- SearchViewModel에서
```swift 
private func startObserving() {
    $query
        .debounce(for: 0.25, scheduler: DispatchQueue.main)
        .sink { _ in
            Task { [weak self] in await self?.searchTickers() }
        }
        .store(in: &cancellables)
/*
정석대로 Combine에서 퍼블리셔를 만들려면 PassthroughSubject 같은 걸 직접 선언해야 하지만,
SwiftUI에서는 `@Published`만 붙이면 자동 퍼블리셔 생성이 되기 때문에 훨씬 간단
`query` 값이 바뀌면 → debounce(0.25초 대기) → `searchTickers()` 실행
debounce는 빠르게 입력하는 중간엔 무시하고, 0.25초 이상 멈췄을 때만 호출
`Task`로 감싸 `await`를 사용함으로써 **비동기 함수 호출 가능**
*/
    $query
        .filter { $0.isEmpty }
        .sink { [weak self] _ in self?.phase = .initial }
        .store(in: &cancellables)
/*
- 사용자가 쿼리를 모두 지워서 빈 문자열이 되면 → `phase`를 `.initial`로 초기화
- 뷰에서는 이 상태를 감지해서 “입력 전” 화면 등을 보여줄 수 있음
*/
}

```
- `@Published`는 내부적으로 **Combine의 퍼블리셔를 자동 생성**합니다.
- 즉, 실제로는 다음과 같은 퍼블리셔가 **자동으로 생깁니다**:

```swift
$query  // 타입은 Published<String>.Publisher
```
그림으로 보는 흐름

```Text
[TextField] --바인딩--> [@Published query]
        |
        | Combine 관찰 (debounce + sink)
        ↓
[searchTickers()] 비동기 호출
        ↓
[phase] 업데이트 → View에 반영
```

- MainListView에서 SwiftUI Concurrency
```swift
struct MainListView: View {
    
    @EnvironmentObject var appVM: AppViewModel
    @StateObject var quotesVM = QuotesViewModel()
    @StateObject var searchVM = SearchViewModel()
    
    var body: some View {
        tickerListView
            .listStyle(.plain)
            .overlay { overlayView }
            .toolbar {
                titleToolbar
                attributionToolbar
            }
            .searchable(text: $searchVM.query)
            .refreshable { await quotesVM.fetchQuotes(tickers: appVM.tickers) }
            .task(id: appVM.tickers) { await quotesVM.fetchQuotes(tickers: appVM.tickers) }
    }
```
- 원래 비동기 함수 호출시 Task{}로 감쌓야 하지만 `refreshable`과 `task(id:)` 모두 내부적으로 `Task` 컨텍스트에서 실행되므로 **별도로 `Task {}`로 감싸지 않아도 됩니다**.
- `id:`는 Task의 **재실행 조건**을 지정하는 용도이며, 값이 바뀌면 해당 Task는 자동으로 다시 실행됩니다.

1. 화면이 나타남 → `.task(id:)`로 현재 `tickers`에 대한 시세 자동 fetch
2. 사용자가 검색 → `tickers` 값 변경 → 자동으로 `.task(id:)` 다시 실행
3. 사용자가 리스트를 아래로 당김 → `.refreshable` 실행 → 시세 재요청

- 참고 앱 데이터 저장 방식 비교
<img width="630" height="225" alt="image" src="https://github.com/user-attachments/assets/eeb60f80-b102-47ec-8a69-351807e60638" />



## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #6 
