### PR TITLE
Feat/#7 quote summary view

### DIFF
--- a/TradeUp/TradeUp.xcodeproj/project.pbxproj
+++ b/TradeUp/TradeUp.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		042B0C9E2E227F3E00B4A017 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042B0C9D2E227F3E00B4A017 /* SearchViewModel.swift */; };
 		048328692E3111B1006204CF /* TickerListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048328682E3111B1006204CF /* TickerListRepository.swift */; };
 		0483286B2E311640006204CF /* MockTickerListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0483286A2E311640006204CF /* MockTickerListRepository.swift */; };
+		0483287B2E321343006204CF /* StockTickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0483287A2E321343006204CF /* StockTickerView.swift */; };
+		0483287D2E321380006204CF /* TickerQuoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0483287C2E321380006204CF /* TickerQuoteViewModel.swift */; };
 		04D8F9E12E28E5CE00DE046E /* StockRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D8F9E02E28E5CE00DE046E /* StockRepository.swift */; };
 		04D8F9E32E28F24500DE046E /* MockStocksAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */; };
 		2F3D68E42E1D4210005148D9 /* TradeUpApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */; };
@@ -55,6 +57,8 @@
 		042B0C9D2E227F3E00B4A017 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		048328682E3111B1006204CF /* TickerListRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerListRepository.swift; sourceTree = "<group>"; };
 		0483286A2E311640006204CF /* MockTickerListRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTickerListRepository.swift; sourceTree = "<group>"; };
+		0483287A2E321343006204CF /* StockTickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockTickerView.swift; sourceTree = "<group>"; };
+		0483287C2E321380006204CF /* TickerQuoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerQuoteViewModel.swift; sourceTree = "<group>"; };
 		04D8F9E02E28E5CE00DE046E /* StockRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockRepository.swift; sourceTree = "<group>"; };
 		04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStocksAPI.swift; sourceTree = "<group>"; };
 		2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeUpApp.swift; sourceTree = "<group>"; };
@@ -117,6 +121,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		048328792E321312006204CF /* Stock Ticker Sheet Views */ = {
+			isa = PBXGroup;
+			children = (
+				0483287A2E321343006204CF /* StockTickerView.swift */,
+			);
+			path = "Stock Ticker Sheet Views";
+			sourceTree = "<group>";
+		};
 		04D8F9DF2E28E5BD00DE046E /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -176,6 +188,7 @@
 				2F3D68D72E1D4210005148D9 /* AppViewModel.swift */,
 				2F3D68D82E1D4210005148D9 /* QuotesViewModel.swift */,
 				042B0C9D2E227F3E00B4A017 /* SearchViewModel.swift */,
+				0483287C2E321380006204CF /* TickerQuoteViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -193,6 +206,7 @@
 		2F3D68E02E1D4210005148D9 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				048328792E321312006204CF /* Stock Ticker Sheet Views */,
 				2F3D68DD2E1D4210005148D9 /* Common */,
 				2F3D68DE2E1D4210005148D9 /* MainListView.swift */,
 				2F3D68DF2E1D4210005148D9 /* TickerListRowView.swift */,
@@ -386,6 +400,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2F3D68E42E1D4210005148D9 /* TradeUpApp.swift in Sources */,
+				0483287B2E321343006204CF /* StockTickerView.swift in Sources */,
 				2F3D68E52E1D4210005148D9 /* Quote+Extensions.swift in Sources */,
 				042B0C9E2E227F3E00B4A017 /* SearchViewModel.swift in Sources */,
 				2F3D68E62E1D4210005148D9 /* Stubs.swift in Sources */,
@@ -395,6 +410,7 @@
 				2F3D68E92E1D4210005148D9 /* AppViewModel.swift in Sources */,
 				2F3D68EA2E1D4210005148D9 /* QuotesViewModel.swift in Sources */,
 				2F3D68EB2E1D4210005148D9 /* EmptyStateView.swift in Sources */,
+				0483287D2E321380006204CF /* TickerQuoteViewModel.swift in Sources */,
 				2F3D68EC2E1D4210005148D9 /* ErrorStateView.swift in Sources */,
 				04D8F9E32E28F24500DE046E /* MockStocksAPI.swift in Sources */,
 				042B0C9C2E227F2F00B4A017 /* SearchView.swift in Sources */,

--- a/TradeUp/TradeUp.xcodeproj/project.pbxproj
+++ b/TradeUp/TradeUp.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		0483287D2E321380006204CF /* TickerQuoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0483287C2E321380006204CF /* TickerQuoteViewModel.swift */; };
 		04D8F9E12E28E5CE00DE046E /* StockRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D8F9E02E28E5CE00DE046E /* StockRepository.swift */; };
 		04D8F9E32E28F24500DE046E /* MockStocksAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */; };
+		04E2B75F2E38F58200B11533 /* DateRangePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E2B75E2E38F58200B11533 /* DateRangePickerView.swift */; };
+		04E2B7612E38F8D800B11533 /* ChartRange+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E2B7602E38F8D800B11533 /* ChartRange+Extensions.swift */; };
 		2F3D68E42E1D4210005148D9 /* TradeUpApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */; };
 		2F3D68E52E1D4210005148D9 /* Quote+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68CE2E1D4210005148D9 /* Quote+Extensions.swift */; };
 		2F3D68E62E1D4210005148D9 /* Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68D02E1D4210005148D9 /* Stubs.swift */; };
@@ -61,6 +63,8 @@
 		0483287C2E321380006204CF /* TickerQuoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerQuoteViewModel.swift; sourceTree = "<group>"; };
 		04D8F9E02E28E5CE00DE046E /* StockRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockRepository.swift; sourceTree = "<group>"; };
 		04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStocksAPI.swift; sourceTree = "<group>"; };
+		04E2B75E2E38F58200B11533 /* DateRangePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangePickerView.swift; sourceTree = "<group>"; };
+		04E2B7602E38F8D800B11533 /* ChartRange+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChartRange+Extensions.swift"; sourceTree = "<group>"; };
 		2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeUpApp.swift; sourceTree = "<group>"; };
 		2F3D68CE2E1D4210005148D9 /* Quote+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quote+Extensions.swift"; sourceTree = "<group>"; };
 		2F3D68D02E1D4210005148D9 /* Stubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stubs.swift; sourceTree = "<group>"; };
@@ -125,6 +129,7 @@
 			isa = PBXGroup;
 			children = (
 				0483287A2E321343006204CF /* StockTickerView.swift */,
+				04E2B75E2E38F58200B11533 /* DateRangePickerView.swift */,
 			);
 			path = "Stock Ticker Sheet Views";
 			sourceTree = "<group>";
@@ -150,6 +155,7 @@
 			isa = PBXGroup;
 			children = (
 				2F3D68CE2E1D4210005148D9 /* Quote+Extensions.swift */,
+				04E2B7602E38F8D800B11533 /* ChartRange+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -407,6 +413,7 @@
 				2F3D68E72E1D4210005148D9 /* TickerListRowData.swift in Sources */,
 				042B0C9A2E227E8A00B4A017 /* FetchPhase.swift in Sources */,
 				2F3D68E82E1D4210005148D9 /* Utils.swift in Sources */,
+				04E2B7612E38F8D800B11533 /* ChartRange+Extensions.swift in Sources */,
 				2F3D68E92E1D4210005148D9 /* AppViewModel.swift in Sources */,
 				2F3D68EA2E1D4210005148D9 /* QuotesViewModel.swift in Sources */,
 				2F3D68EB2E1D4210005148D9 /* EmptyStateView.swift in Sources */,
@@ -419,6 +426,7 @@
 				2F3D68EE2E1D4210005148D9 /* MainListView.swift in Sources */,
 				048328692E3111B1006204CF /* TickerListRepository.swift in Sources */,
 				0483286B2E311640006204CF /* MockTickerListRepository.swift in Sources */,
+				04E2B75F2E38F58200B11533 /* DateRangePickerView.swift in Sources */,
 				2F3D68EF2E1D4210005148D9 /* TickerListRowView.swift in Sources */,
 				2F3D68F02E1D4210005148D9 /* ContentView.swift in Sources */,
 			);

--- a/TradeUp/TradeUp.xcodeproj/project.pbxproj
+++ b/TradeUp/TradeUp.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		04D8F9E32E28F24500DE046E /* MockStocksAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */; };
 		04E2B75F2E38F58200B11533 /* DateRangePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E2B75E2E38F58200B11533 /* DateRangePickerView.swift */; };
 		04E2B7612E38F8D800B11533 /* ChartRange+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E2B7602E38F8D800B11533 /* ChartRange+Extensions.swift */; };
+		04E2B7632E39FE1900B11533 /* QuoteDetailRowColumnItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E2B7622E39FE1900B11533 /* QuoteDetailRowColumnItem.swift */; };
+		04E2B7672E3A00EA00B11533 /* Foundation+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E2B7662E3A00EA00B11533 /* Foundation+Extensions.swift */; };
 		2F3D68E42E1D4210005148D9 /* TradeUpApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */; };
 		2F3D68E52E1D4210005148D9 /* Quote+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68CE2E1D4210005148D9 /* Quote+Extensions.swift */; };
 		2F3D68E62E1D4210005148D9 /* Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D68D02E1D4210005148D9 /* Stubs.swift */; };
@@ -65,6 +67,8 @@
 		04D8F9E22E28F24500DE046E /* MockStocksAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStocksAPI.swift; sourceTree = "<group>"; };
 		04E2B75E2E38F58200B11533 /* DateRangePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangePickerView.swift; sourceTree = "<group>"; };
 		04E2B7602E38F8D800B11533 /* ChartRange+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChartRange+Extensions.swift"; sourceTree = "<group>"; };
+		04E2B7622E39FE1900B11533 /* QuoteDetailRowColumnItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteDetailRowColumnItem.swift; sourceTree = "<group>"; };
+		04E2B7662E3A00EA00B11533 /* Foundation+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Foundation+Extensions.swift"; sourceTree = "<group>"; };
 		2F3D68CC2E1D4210005148D9 /* TradeUpApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeUpApp.swift; sourceTree = "<group>"; };
 		2F3D68CE2E1D4210005148D9 /* Quote+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Quote+Extensions.swift"; sourceTree = "<group>"; };
 		2F3D68D02E1D4210005148D9 /* Stubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stubs.swift; sourceTree = "<group>"; };
@@ -130,6 +134,7 @@
 			children = (
 				0483287A2E321343006204CF /* StockTickerView.swift */,
 				04E2B75E2E38F58200B11533 /* DateRangePickerView.swift */,
+				04E2B7622E39FE1900B11533 /* QuoteDetailRowColumnItem.swift */,
 			);
 			path = "Stock Ticker Sheet Views";
 			sourceTree = "<group>";
@@ -156,6 +161,7 @@
 			children = (
 				2F3D68CE2E1D4210005148D9 /* Quote+Extensions.swift */,
 				04E2B7602E38F8D800B11533 /* ChartRange+Extensions.swift */,
+				04E2B7662E3A00EA00B11533 /* Foundation+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -410,6 +416,7 @@
 				2F3D68E52E1D4210005148D9 /* Quote+Extensions.swift in Sources */,
 				042B0C9E2E227F3E00B4A017 /* SearchViewModel.swift in Sources */,
 				2F3D68E62E1D4210005148D9 /* Stubs.swift in Sources */,
+				04E2B7632E39FE1900B11533 /* QuoteDetailRowColumnItem.swift in Sources */,
 				2F3D68E72E1D4210005148D9 /* TickerListRowData.swift in Sources */,
 				042B0C9A2E227E8A00B4A017 /* FetchPhase.swift in Sources */,
 				2F3D68E82E1D4210005148D9 /* Utils.swift in Sources */,
@@ -422,6 +429,7 @@
 				04D8F9E32E28F24500DE046E /* MockStocksAPI.swift in Sources */,
 				042B0C9C2E227F2F00B4A017 /* SearchView.swift in Sources */,
 				2F3D68ED2E1D4210005148D9 /* LoadingStateView.swift in Sources */,
+				04E2B7672E3A00EA00B11533 /* Foundation+Extensions.swift in Sources */,
 				04D8F9E12E28E5CE00DE046E /* StockRepository.swift in Sources */,
 				2F3D68EE2E1D4210005148D9 /* MainListView.swift in Sources */,
 				048328692E3111B1006204CF /* TickerListRepository.swift in Sources */,

--- a/TradeUp/TradeUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TradeUp/TradeUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/jeonguk29/YahooStocksKit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "e2350743c691130221ebd0533ce9b60ffcb2c5bc"
+        "revision" : "098db3b4aa5adea6e5d7d1e12f888d6a96c2ead0"
       }
     }
   ],

--- a/TradeUp/TradeUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TradeUp/TradeUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/jeonguk29/YahooStocksKit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "098db3b4aa5adea6e5d7d1e12f888d6a96c2ead0"
+        "revision" : "b702efe9d827cfb44da9a6170db7f368679d8f57"
       }
     }
   ],

--- a/TradeUp/TradeUp/Extensions/ChartRange+Extensions.swift
+++ b/TradeUp/TradeUp/Extensions/ChartRange+Extensions.swift
@@ -1,0 +1,31 @@
+//
+//  ChartRange+Extensions.swift
+//  TradeUp
+//
+//  Created by MAC on 7/29/25.
+//
+
+import Foundation
+import  StocksAPI
+
+extension ChartRange: Identifiable {
+    
+    public var id: Self { self } // 검색 해보자 Self, self 엘런 자료에 있었던거 같음
+    
+    var title: String {
+        switch self {
+        case .oneDay: return "1D"
+        case .oneWeek: return "1W"
+        case .oneMonth: return "1M"
+        case .threeMonth: return "3M"
+        case .sixMonth: return "6M"
+        case .oneYear: return "1Y"
+        case .twoYear: return "2Y"
+        case .fiveYear: return "5Y"
+        case .tenYear: return "10Y"
+        case .ytd: return "YTD"
+        case .max: return "ALL"
+        }
+    }
+    
+}

--- a/TradeUp/TradeUp/Extensions/ChartRange+Extensions.swift
+++ b/TradeUp/TradeUp/Extensions/ChartRange+Extensions.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import  StocksAPI
+import StocksAPI
 
 extension ChartRange: Identifiable {
     

--- a/TradeUp/TradeUp/Extensions/ChartRange+Extensions.swift
+++ b/TradeUp/TradeUp/Extensions/ChartRange+Extensions.swift
@@ -8,9 +8,10 @@
 import Foundation
 import StocksAPI
 
+// MARK: - 차트 날짜 범위
 extension ChartRange: Identifiable {
     
-    public var id: Self { self } // 검색 해보자 Self, self 엘런 자료에 있었던거 같음
+    public var id: Self { self }
     
     var title: String {
         switch self {

--- a/TradeUp/TradeUp/Extensions/Foundation+Extensions.swift
+++ b/TradeUp/TradeUp/Extensions/Foundation+Extensions.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// 큰 수 단위를 약어로 표시하는 extension
+// MARK: - 큰 수 단위를 약어로 표시하는 extension
 extension Double {
     
     //https://stackoverflow.com/questions/18267211/ios-convert-large-numbers-to-smaller-format

--- a/TradeUp/TradeUp/Extensions/Foundation+Extensions.swift
+++ b/TradeUp/TradeUp/Extensions/Foundation+Extensions.swift
@@ -1,0 +1,48 @@
+//
+//  Foundation+Extensions.swift
+//  TradeUp
+//
+//  Created by MAC on 7/30/25.
+//
+
+import Foundation
+
+// 큰 수 단위를 약어로 표시하는 extension
+extension Double {
+    
+    //https://stackoverflow.com/questions/18267211/ios-convert-large-numbers-to-smaller-format
+    //    gbitaudeau
+    func formatUsingAbbrevation () -> String {
+        let numFormatter = NumberFormatter()
+        
+        typealias Abbrevation = (threshold:Double, divisor:Double, suffix:String)
+        let abbreviations:[Abbrevation] = [(0, 1, ""),
+                                           (1000.0, 1000.0, "K"),
+                                           (100_000.0, 1_000_000.0, "M"),
+                                           (100_000_000.0, 1_000_000_000.0, "B"),
+                                           (100_000_000_000.0, 1_000_000_000_000.0, "T")]
+        let startValue = Double (abs(self))
+        let abbreviation:Abbrevation = {
+            var prevAbbreviation = abbreviations[0]
+            for tmpAbbreviation in abbreviations {
+                if (startValue < tmpAbbreviation.threshold) {
+                    break
+                }
+                prevAbbreviation = tmpAbbreviation
+            }
+            return prevAbbreviation
+        } ()
+        
+        let value = Double(self) / abbreviation.divisor
+        numFormatter.positiveSuffix = abbreviation.suffix
+        numFormatter.negativeSuffix = abbreviation.suffix
+        numFormatter.allowsFloats = true
+        numFormatter.minimumIntegerDigits = 1
+        numFormatter.minimumFractionDigits = 0
+        numFormatter.maximumFractionDigits = 3
+        numFormatter.decimalSeparator = ","
+        
+        return numFormatter.string(from: NSNumber (value:value))!
+    }
+    
+}

--- a/TradeUp/TradeUp/Extensions/Quote+Extensions.swift
+++ b/TradeUp/TradeUp/Extensions/Quote+Extensions.swift
@@ -11,11 +11,11 @@ import StocksAPI
 extension Quote {
     
     var isTrading: Bool {
-         guard let marketState, marketState == "REGULAR" else {
-             return false
-         }
-         return true
-     }
+        guard let marketState, marketState == "REGULAR" else {
+            return false
+        }
+        return true
+    }
     
     var regularPriceText: String? {
         Utils.format(value: regularMarketPrice)
@@ -33,5 +33,70 @@ extension Quote {
     var postPriceDiffText: String? {
         guard let text = Utils.format(value: postMarketPriceChange) else { return nil }
         return text.hasPrefix("-") ? text : "+\(text)"
+    }
+    
+    var highText: String {
+        Utils.format(value: regularMarketDayHigh) ?? "-"
+    }
+    
+    var openText: String {
+        Utils.format(value: regularMarketOpen) ?? "-"
+    }
+    
+    var lowText: String {
+        Utils.format(value: regularMarketDayLow) ?? "-"
+    }
+    
+    var volText: String {
+        regularMarketVolume?.formatUsingAbbrevation() ?? "-"
+    }
+    
+    var peText: String {
+        Utils.format(value: trailingPE) ?? "-"
+    }
+    
+    var mktCapText: String {
+        marketCap?.formatUsingAbbrevation() ?? "-"
+    }
+    
+    var fiftyTwoWHText: String {
+        Utils.format(value: fiftyTwoWeekHigh) ?? "-"
+    }
+    
+    var fiftyTwoWLText: String {
+        Utils.format(value: fiftyTwoWeekLow) ?? "-"
+    }
+    
+    var avgVolText: String {
+        averageDailyVolume3Month?.formatUsingAbbrevation() ?? "-"
+    }
+    
+    var yieldText: String { "-" }
+    var betaText: String { "-" }
+    
+    var epsText: String {
+        Utils.format(value: epsTrailingTwelveMonths) ?? "-"
+    }
+    
+    var columnItems: [QuoteDetailRowColumnItem] {
+        [
+            QuoteDetailRowColumnItem(rows: [
+                QuoteDetailRowColumnItem.RowItem(title: "Open", value: openText),
+                QuoteDetailRowColumnItem.RowItem(title: "High", value: highText),
+                QuoteDetailRowColumnItem.RowItem(title: "Low", value: lowText)
+            ]), QuoteDetailRowColumnItem(rows: [
+                QuoteDetailRowColumnItem.RowItem(title: "Vol", value: volText),
+                QuoteDetailRowColumnItem.RowItem(title: "P/E", value: peText),
+                QuoteDetailRowColumnItem.RowItem(title: "Mkt Cap", value: mktCapText)
+            ]), QuoteDetailRowColumnItem(rows: [
+                QuoteDetailRowColumnItem.RowItem(title: "52W H", value: fiftyTwoWHText), // 52주 최고, 최저가
+                QuoteDetailRowColumnItem.RowItem(title: "52W L", value: fiftyTwoWLText),
+                QuoteDetailRowColumnItem.RowItem(title: "Avg Vol", value: avgVolText)
+            ]), QuoteDetailRowColumnItem(rows: [
+                QuoteDetailRowColumnItem.RowItem(title: "Yield", value: yieldText),
+                QuoteDetailRowColumnItem.RowItem(title: "Beta", value: betaText),
+                QuoteDetailRowColumnItem.RowItem(title: "EPS", value: epsText)
+            ])
+        ]
     }
 }

--- a/TradeUp/TradeUp/Extensions/Quote+Extensions.swift
+++ b/TradeUp/TradeUp/Extensions/Quote+Extensions.swift
@@ -10,6 +10,13 @@ import StocksAPI
 
 extension Quote {
     
+    var isTrading: Bool {
+         guard let marketState, marketState == "REGULAR" else {
+             return false
+         }
+         return true
+     }
+    
     var regularPriceText: String? {
         Utils.format(value: regularMarketPrice)
     }
@@ -19,4 +26,12 @@ extension Quote {
         return text.hasPrefix("-") ? text : "+\(text)"
     }
     
+    var postPriceText: String? {
+        Utils.format(value: postMarketPrice)
+    }
+    
+    var postPriceDiffText: String? {
+        guard let text = Utils.format(value: postMarketPriceChange) else { return nil }
+        return text.hasPrefix("-") ? text : "+\(text)"
+    }
 }

--- a/TradeUp/TradeUp/Mocks & Stubs/Stubs.swift
+++ b/TradeUp/TradeUp/Mocks & Stubs/Stubs.swift
@@ -13,13 +13,16 @@ extension Ticker {
     
     static var stubs: [Ticker] {
         [
-            Ticker(symbol: "AAPL", shortname: "Apple Inc."),
+            Ticker(symbol: "AAPL", shortname: "Apple Inc.", exchDisp: "NASDAQ"),
             Ticker(symbol: "TSLA", shortname: "Tesla."),
             Ticker(symbol: "NVDA", shortname: "Nvidia Corp."),
             Ticker(symbol: "AMD", shortname: "Advanced Micro Device")
         ]
     }
-
+    
+    static var stub: Ticker {
+        stubs[0]
+    }
 }
 
 extension Quote {
@@ -39,7 +42,32 @@ extension Quote {
         return dict
     }
     
-  
+    static func stub(isTrading: Bool) -> Quote {
+        Quote(
+            currency: "USD",
+            marketState: isTrading ? "REGULAR" : "CLOSED",
+            fullExchangeName: nil,
+            displayName: nil,
+            symbol: "AAPL",
+            regularMarketPrice: 150.43,
+            regularMarketChange: -2.31,
+            regularMarketChangePercent: nil,
+            regularMarketChangePreviousClose: nil,
+            postMarketPrice: 172.43,
+            postMarketPriceChange: 5.34,
+            regularMarketOpen: 150,
+            regularMarketDayHigh: 160,
+            regularMarketDayLow: 140,
+            regularMarketVolume: 86_000_000.0,
+            trailingPE: 24.54,
+            marketCap: 2_300_000_000_000.0,
+            fiftyTwoWeekLow: 130.42,
+            fiftyTwoWeekHigh: 183.77,
+            averageDailyVolume3Month: 80_128_000.0,
+            trailingAnnualDividendYield: nil,
+            epsTrailingTwelveMonths: 6.05
+        )
+    }
 }
 
 #endif

--- a/TradeUp/TradeUp/ViewModels/AppViewModel.swift
+++ b/TradeUp/TradeUp/ViewModels/AppViewModel.swift
@@ -15,6 +15,8 @@ class AppViewModel: ObservableObject {
     @Published var tickers: [Ticker] = [] {
         didSet { saveTickers() } // 값에 변경이 생기면 로칼에 저장
     }
+    @Published var selectedTicker: Ticker?
+    
     var titleText = "TradeUp"
     @Published var subtitleText: String
     var emptyTickersText = "Search & add symbol to see stock quotes"

--- a/TradeUp/TradeUp/ViewModels/QuotesViewModel.swift
+++ b/TradeUp/TradeUp/ViewModels/QuotesViewModel.swift
@@ -13,7 +13,7 @@ import StocksAPI
 class QuotesViewModel: ObservableObject {
     
     @Published var quotesDict: [String: Quote] = [:]
-    private let stocksAPI: StockRepository
+    let stocksAPI: StockRepository
     
     init(stocksAPI: StockRepository = StocksAPI()) {
         self.stocksAPI = stocksAPI

--- a/TradeUp/TradeUp/ViewModels/TickerQuoteViewModel.swift
+++ b/TradeUp/TradeUp/ViewModels/TickerQuoteViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  TickerQuoteViewModel.swift
+//  TradeUp
+//
+//  Created by MAC on 7/24/25.
+//
+
+import SwiftUI
+import StocksAPI
+
+@MainActor
+class TickerQuoteViewModel: ObservableObject {
+    
+    @Published var phase = FetchPhase<Quote>.initial
+    var quote: Quote? { phase.value }
+    var error: Error? { phase.error }
+    
+    let ticker: Ticker
+    let stocksAPI: StockRepository
+    
+    init(ticker: Ticker, stocksAPI: StockRepository = StocksAPI()) {
+        self.ticker = ticker
+        self.stocksAPI = stocksAPI
+    }
+    
+    func fetchQuote() async {
+        phase = .fetching
+        
+        do {
+            let response = try await stocksAPI.fetchQuotes(symbols: ticker.symbol)
+            if let quote = response.first {
+                phase = .success(quote)
+            } else {
+                phase = .empty
+            }
+        } catch {
+            print(error.localizedDescription)
+            phase = .failure(error)
+        }
+    }
+}

--- a/TradeUp/TradeUp/Views/MainListView.swift
+++ b/TradeUp/TradeUp/Views/MainListView.swift
@@ -24,6 +24,10 @@ struct MainListView: View {
             }
             .searchable(text: $searchVM.query)
             .refreshable { await quotesVM.fetchQuotes(tickers: appVM.tickers) }
+            .sheet(item: $appVM.selectedTicker) {
+                StockTickerView(quoteVM: .init(ticker: $0, stocksAPI: quotesVM.stocksAPI))
+                    .presentationDetents([.height(560)]) //?
+            }
             .task(id: appVM.tickers) { await quotesVM.fetchQuotes(tickers: appVM.tickers) }
     }
     
@@ -37,7 +41,9 @@ struct MainListView: View {
                         price: quotesVM.priceForTicker(ticker),
                         type: .main))
                 .contentShape(Rectangle())
-                .onTapGesture { }
+                .onTapGesture {
+                    appVM.selectedTicker = ticker
+                }
             }
             .onDelete { appVM.removeTickers(atOffsets: $0) }
         }

--- a/TradeUp/TradeUp/Views/SearchView.swift
+++ b/TradeUp/TradeUp/Views/SearchView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import StocksAPI
 
-@MainActor
 struct SearchView: View {
     
     @EnvironmentObject var appVM: AppViewModel
@@ -32,9 +31,16 @@ struct SearchView: View {
                     )
                 )
             )
-            //.contentShape(Rectangle())
-            //.onTapGesture {}
+            .contentShape(Rectangle())
+            .onTapGesture {
+                Task { @MainActor in
+                    appVM.selectedTicker = ticker
+                }
+            }
         }
+        .background(content: {
+            Color.white
+        })
         .listStyle(.plain)
         .refreshable { await quotesVM.fetchQuotes(tickers: searchVM.tickers) }
         .task(id: searchVM.tickers) { await quotesVM.fetchQuotes(tickers: searchVM.tickers) }
@@ -106,7 +112,7 @@ struct SearchView_Previews: PreviewProvider {
             NavigationStack {
                 SearchView(quotesVM: quotesVM, searchVM: stubbedSearchVM)
             }
-            .searchable(text: $stubbedSearchVM.query) 
+            .searchable(text: $stubbedSearchVM.query)
             .previewDisplayName("Results")
             
             NavigationStack {

--- a/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/DateRangePickerView.swift
+++ b/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/DateRangePickerView.swift
@@ -1,0 +1,52 @@
+//
+//  DateRangePickerView.swift
+//  TradeUp
+//
+//  Created by MAC on 7/29/25.
+//
+
+import SwiftUI
+import StocksAPI
+
+struct DateRangePickerView: View {
+    
+    let rangeTypes = ChartRange.allCases
+    @Binding var selectedRange: ChartRange
+    
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 16) {
+                ForEach(self.rangeTypes) { dateRange in
+                    Button {
+                        self.selectedRange = dateRange
+                    } label: {
+                        Text(dateRange.title)
+                            .font(.callout.bold())
+                            .padding(8)
+                    }
+                    .buttonStyle(.plain)
+                    .contentShape(Rectangle())
+                    .background {
+                        if dateRange == selectedRange {
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color.gray.opacity(0.4))
+                        }
+                    }
+                }
+                
+            }.padding(.horizontal)
+        }
+        .scrollIndicators(.hidden)
+    }
+}
+
+struct DateRangePickerView_Previews: PreviewProvider {
+    
+    @State static var dateRange = ChartRange.oneDay
+    
+    static var previews: some View {
+        DateRangePickerView(selectedRange: $dateRange)
+            .padding(.vertical)
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/QuoteDetailRowColumnItem.swift
+++ b/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/QuoteDetailRowColumnItem.swift
@@ -1,0 +1,51 @@
+//
+//  QuoteDetailRowColumnItem.swift
+//  TradeUp
+//
+//  Created by MAC on 7/30/25.
+//
+
+import SwiftUI
+
+struct QuoteDetailRowColumnItem: Identifiable {
+    
+    let id = UUID()
+    let rows: [RowItem]
+    
+    struct RowItem: Identifiable {
+        
+        let id = UUID()
+        let title: String
+        let value: String
+    }
+}
+
+struct QuoteDetailRowColumnView: View {
+    
+    let item: QuoteDetailRowColumnItem
+    
+    var body: some View {
+        VStack(spacing: 6) {
+            ForEach(item.rows) { row in
+                HStack(alignment: .lastTextBaseline) {
+                    Text(row.title).foregroundColor(.gray)
+                    Spacer()
+                    Text(row.value)
+                }
+            }
+        }
+        .frame(width: 120)
+    }
+}
+
+struct QuoteDetailRowColumnView_Previews: PreviewProvider {
+    static var previews: some View {
+        QuoteDetailRowColumnView(item: .init(rows: [
+            .init(title: "Open", value: "164.23"),
+            .init(title: "Open", value: "164.23"),
+            .init(title: "Open", value: "164.23")
+        ])
+        )
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/StockTickerView.swift
+++ b/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/StockTickerView.swift
@@ -66,6 +66,16 @@ struct StockTickerView: View {
                 .padding(.horizontal)
             
             Divider()
+            
+            DateRangePickerView(selectedRange: $selectedRange)
+            
+            Divider()
+            
+            Text("Chart View Placeholder")
+                .padding(.horizontal)
+                .frame(maxWidth: .infinity, minHeight: 220)
+            
+            Divider().padding([.horizontal, .top])
         }
         .scrollIndicators(.hidden)
         .frame(maxWidth: .infinity, alignment: .leading) // 이게 alignment: .leading 어떤 의미지?

--- a/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/StockTickerView.swift
+++ b/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/StockTickerView.swift
@@ -16,8 +16,120 @@ struct StockTickerView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-         
+            headerView.padding(.horizontal)
+            
+            Divider()
+                .padding(.vertical, 8)
+                .padding(.horizontal)
+            scrollView
         }
+        .padding(.top)
+        .background(Color(uiColor: .systemBackground))
+        .task { await quoteVM.fetchQuote() }
+    }
+    
+    // 심볼, 종목 이름, 닫기 버튼
+    private var headerView: some View {
+        HStack(alignment: .lastTextBaseline) {
+            Text(quoteVM.ticker.symbol).font(.title.bold())
+            if let shortName = quoteVM.ticker.shortname {
+                Text(shortName)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Color(uiColor: .secondaryLabel))
+            }
+            Spacer()
+            closeButton
+        }
+    }
+    
+    private var closeButton: some View {
+        Button {
+            dismiss()
+        } label: {
+            Circle()
+                .frame(width: 36, height: 36)
+                .foregroundColor(.gray.opacity(0.1))
+                .overlay {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 18).bold())
+                        .foregroundColor(Color(uiColor: .secondaryLabel))
+                }
+        }
+        .buttonStyle(.plain)
+    }
+    
+    private var scrollView: some View {
+        ScrollView {
+            priceDiffRowView
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 8)
+                .padding(.horizontal)
+            
+            Divider()
+        }
+        .scrollIndicators(.hidden)
+        .frame(maxWidth: .infinity, alignment: .leading) // 이게 alignment: .leading 어떤 의미지?
+    }
+    
+    // 가격 및 등락 정보 표시 (장중 거래 중, 장 종료 후)
+    private var priceDiffRowView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let quote = quoteVM.quote {
+                HStack {
+                    if quote.isTrading,
+                       let price = quote.regularPriceText,
+                       let diff = quote.regularDiffText {
+                        priceDiffStackView(price: price, diff: diff, caption: nil) // 거래중일때는 nil
+                    } else {
+                        if let atCloseText = quote.regularPriceText,
+                           let atCloseDiffText = quote.regularDiffText {
+                            priceDiffStackView(price: atCloseText, diff: atCloseDiffText, caption: "At Close")
+                        }
+                        
+                        if let afterHourText = quote.postPriceText,
+                           let afterHourDiffText = quote.postPriceDiffText {
+                            priceDiffStackView(price: afterHourText, diff: afterHourDiffText, caption: "After Hours")
+                        }
+                    }
+                    
+                    Spacer()
+                }
+            }
+            exchangeCurrencyView // 통화, 거래서 표현
+        }
+    }
+    
+    // 가격/변동 정보 출력 포맷
+    private func priceDiffStackView(price: String, diff: String, caption: String?) -> some View {
+        VStack(alignment: .leading) {
+            HStack(alignment: .lastTextBaseline, spacing: 16) {
+                Text(price).font(.headline.bold())
+                Text(diff).font(.subheadline.weight(.semibold))
+                    .foregroundColor(diff.hasPrefix("-") ? .red : .green)
+            }
+            
+            if let caption {
+                Text(caption)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Color(uiColor: .secondaryLabel))
+            }
+        }
+    }
+    
+    // 거래소 및 통화 정보
+    private var exchangeCurrencyView: some View {
+        HStack(spacing: 4) {
+            if let exchange = quoteVM.ticker.exchDisp {
+                Text(exchange)
+            }
+            
+            if let currency = quoteVM.quote?.currency {
+                Text("·")
+                Text(currency)
+            }
+        }
+        .font(.subheadline.weight(.semibold))
+        .foregroundColor(Color(uiColor: .secondaryLabel))
     }
 }
 

--- a/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/StockTickerView.swift
+++ b/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/StockTickerView.swift
@@ -28,7 +28,7 @@ struct StockTickerView: View {
         .task { await quoteVM.fetchQuote() }
     }
     
-    // 심볼, 종목 이름, 닫기 버튼
+    // MARK: - 심볼, 종목 이름, 닫기 버튼
     private var headerView: some View {
         HStack(alignment: .lastTextBaseline) {
             Text(quoteVM.ticker.symbol).font(.title.bold())
@@ -58,6 +58,7 @@ struct StockTickerView: View {
         .buttonStyle(.plain)
     }
     
+    // MARK: - 전체 세로 스크롤 뷰
     private var scrollView: some View {
         ScrollView {
             priceDiffRowView
@@ -82,10 +83,10 @@ struct StockTickerView: View {
             
         }
         .scrollIndicators(.hidden)
-        .frame(maxWidth: .infinity, alignment: .leading) // 이게 alignment: .leading 어떤 의미지?
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
     
-    // 가격 및 등락 정보 표시 (장중 거래 중, 장 종료 후)
+   // MARK: -  가격 및 등락 정보 표시 (장중 거래 중, 장 종료 후)
     private var priceDiffRowView: some View {
         VStack(alignment: .leading, spacing: 8) {
             if let quote = quoteVM.quote {
@@ -113,7 +114,7 @@ struct StockTickerView: View {
         }
     }
     
-    // 가격/변동 정보 출력 포맷
+    // MARK: - 가격/변동 정보 출력 포맷
     private func priceDiffStackView(price: String, diff: String, caption: String?) -> some View {
         VStack(alignment: .leading) {
             HStack(alignment: .lastTextBaseline, spacing: 16) {
@@ -130,7 +131,7 @@ struct StockTickerView: View {
         }
     }
     
-    // 거래소 및 통화 정보
+    // MARK: - 거래소 및 통화 정보
     private var exchangeCurrencyView: some View {
         HStack(spacing: 4) {
             if let exchange = quoteVM.ticker.exchDisp {
@@ -146,6 +147,7 @@ struct StockTickerView: View {
         .foregroundColor(Color(uiColor: .secondaryLabel))
     }
     
+    // MARK: - 주식 관련 디테일 정보 (시가, 종가 등등)
     @ViewBuilder
     private var quoteDetailRowView: some View {
         switch quoteVM.phase {

--- a/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/StockTickerView.swift
+++ b/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/StockTickerView.swift
@@ -76,6 +76,10 @@ struct StockTickerView: View {
                 .frame(maxWidth: .infinity, minHeight: 220)
             
             Divider().padding([.horizontal, .top])
+            
+            quoteDetailRowView
+                .frame(maxWidth: .infinity, minHeight: 80)
+            
         }
         .scrollIndicators(.hidden)
         .frame(maxWidth: .infinity, alignment: .leading) // 이게 alignment: .leading 어떤 의미지?
@@ -140,6 +144,30 @@ struct StockTickerView: View {
         }
         .font(.subheadline.weight(.semibold))
         .foregroundColor(Color(uiColor: .secondaryLabel))
+    }
+    
+    @ViewBuilder
+    private var quoteDetailRowView: some View {
+        switch quoteVM.phase {
+        case .fetching: LoadingStateView()
+        case .failure(let error): ErrorStateView(error: "Quote: \(error.localizedDescription)")
+                .padding(.horizontal)
+        case .success(let quote):
+            ScrollView(.horizontal) {
+                HStack(spacing: 16) {
+                    ForEach(quote.columnItems) {
+                        QuoteDetailRowColumnView(item: $0)
+                    }
+                }
+                .padding(.horizontal)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+            }
+            .scrollIndicators(.hidden)
+            
+            
+        default: EmptyView()
+        }
     }
 }
 

--- a/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/StockTickerView.swift
+++ b/TradeUp/TradeUp/Views/Stock Ticker Sheet Views/StockTickerView.swift
@@ -1,0 +1,83 @@
+//
+//  StockTickerView.swift
+//  TradeUp
+//
+//  Created by MAC on 7/24/25.
+//
+
+import SwiftUI
+import StocksAPI
+
+struct StockTickerView: View {
+    
+    @StateObject var quoteVM: TickerQuoteViewModel
+    @State var selectedRange = ChartRange.oneDay
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+         
+        }
+    }
+}
+
+
+struct StockTickerView_Previews: PreviewProvider {
+    
+    static var tradingStubsQuoteVM: TickerQuoteViewModel = {
+        var mockAPI = MockStocksAPI()
+        mockAPI.stubbedFetchQuotesCallback = {
+            [Quote.stub(isTrading: true)]
+        }
+        return TickerQuoteViewModel(ticker: .stub, stocksAPI: mockAPI)
+    }()
+    
+    static var closedStubsQuoteVM: TickerQuoteViewModel = {
+        var mockAPI = MockStocksAPI()
+        mockAPI.stubbedFetchQuotesCallback = {
+            [Quote.stub(isTrading: false)]
+        }
+        return TickerQuoteViewModel(ticker: .stub, stocksAPI: mockAPI)
+    }()
+    
+    
+    static var loadingStubsQuoteVM: TickerQuoteViewModel = {
+        var mockAPI = MockStocksAPI()
+        mockAPI.stubbedFetchQuotesCallback = {
+            await withCheckedContinuation { _ in
+                
+            }
+        }
+        return TickerQuoteViewModel(ticker: .stub, stocksAPI: mockAPI)
+    }()
+    
+    
+    static var errorStubsQuoteVM: TickerQuoteViewModel = {
+        var mockAPI = MockStocksAPI()
+        mockAPI.stubbedFetchQuotesCallback = {
+            throw NSError(domain: "error", code: 0, userInfo: [NSLocalizedDescriptionKey: "An error has been occured"])
+        }
+        return TickerQuoteViewModel(ticker: .stub, stocksAPI: mockAPI)
+    }()
+    
+    static var previews: some View {
+        Group {
+            StockTickerView(quoteVM: tradingStubsQuoteVM)
+                .previewDisplayName("Trading")
+                .frame(height: 700)
+            
+            StockTickerView(quoteVM: closedStubsQuoteVM)
+                .previewDisplayName("Closed")
+                .frame(height: 700)
+            
+            StockTickerView(quoteVM: loadingStubsQuoteVM)
+                .previewDisplayName("Loading Quote")
+                .frame(height: 700)
+            
+            StockTickerView(quoteVM: errorStubsQuoteVM)
+                .previewDisplayName("Error Quote")
+                .frame(height: 700)
+            
+        }.previewLayout(.sizeThatFits)
+    }
+}

--- a/TradeUp/TradeUp/Views/TickerListRowView.swift
+++ b/TradeUp/TradeUp/Views/TickerListRowView.swift
@@ -20,6 +20,7 @@ struct TickerListRowView: View {
                 } label: {
                     image(isSaved: isSaved)
                 }
+                .buttonStyle(.plain)
             }
             
             VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
사용자가 종목 셀을 탭하면 시세 상세 시트를 띄울 수 있도록 상태 바인딩 및 시트 전환 로직을 구현했습니다.

## 🎫 Changes
- `AppViewModel`에 `@Published var selectedTicker: Ticker?` 추가
- `.sheet(item:)`을 통해 `StockTickerView` 연결
- `MainListView`, `SearchView`에서 종목 탭 시 `selectedTicker` 설정
- 종목 선택 시 상세 시트가 등장하도록 데이터 흐름 구성

StockTickerView 종목 시세 상세 UI 뷰 구현
- 종목 심볼, 종목명, 현재가/등락률/통화 정보 출력
- 장중/장마감/After Hours 정보에 따른 분기 처리
- 시세 상세 정보(고가, 저가, PER 등)를 수평 스크롤로 표시
- 상태별 Preview(Mock ViewModel) 구성: 거래 중 / 장 마감 / 로딩 / 에러

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->
StockTickerView를 어떻게 하면 MainListView, SearchView에서 동일하게 띄울지 고민을 많이 했습니다.

## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/869584ae-86c6-45e2-b14e-4c4806754e64" width ="250"> | <img src = "https://github.com/user-attachments/assets/869584ae-86c6-45e2-b14e-4c4806754e64" width ="250"> | <img src = "https://github.com/user-attachments/assets/869584ae-86c6-45e2-b14e-4c4806754e64" width ="250"> |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`종목 선택 → 상세 시세 조회 연결 흐름 정리`
- 🔗 흐름 요약

```
1. 사용자가 종목 셀을 탭함
 ↓
2. AppViewModel의 selectedTicker에 선택된 Ticker 저장
 ↓
3. .sheet(item:)이 트리거되어 StockTickerView가 등장
 ↓
4. StockTickerView 내부에서 TickerQuoteViewModel 생성
 ↓
5. 선택된 종목의 시세 정보 fetch 및 렌더링

```

---

### 🔧 주요 연결 구조

### 1) 상태 연결 MainListView에서

```swift
@Published var selectedTicker: Ticker? // AppViewModel

```

- 선택된 종목 상태를 보존하여 SwiftUI `.sheet(item:)` 트리거로 사용

### 2) 사용자 액션 처리

```swift
.onTapGesture {
    appVM.selectedTicker = ticker
}

```

- 사용자가 종목을 탭하면 `selectedTicker`가 설정되어 시트가 등장

### 3) Sheet 및 ViewModel 전달

```swift
.sheet(item: $appVM.selectedTicker) {
    StockTickerView(
        quoteVM: .init(
            ticker: $0,
            stocksAPI: quotesVM.stocksAPI
        )
    )
}

```

- 선택된 Ticker를 기반으로 `TickerQuoteViewModel`을 생성해 `StockTickerView`에 주입
- 기존에 사용 중인 `quotesVM`의 `stocksAPI` 인스턴스를 재사용하여 의존성 일관성 유지

또한
- `SearchView` 내부에서도 `appVM`은 상위 뷰(MainListView 등)에서 주입한 동일 인스턴스를 참조합니다.
- 따라서 **메인 뷰와 검색 뷰가 동일한 `appVM`을 공유**하게 되며,
- `selectedTicker` 값이 바뀌면 `.sheet(item:)`에 연결된 로직이 작동합니다.
 ```swift
  .onTapGesture {
                Task { @MainActor in
                    appVM.selectedTicker = ticker
                }
            }
```

```text
[MainListView]        [SearchView]
     ↓                     ↓
 .sheet(item:)         .onTapGesture
     ↑                     ↓
  selectedTicker  ←  appVM.selectedTicker = ticker
     ↓
 StockTickerView 등장

```

그 외적으로 알아낸거
- .presentationDetents([.height(560)])는 SwiftUI의 .sheet 뷰 모디파이어에서 시트(sheet)의 높이를 지정하는 속성
```swift
.sheet(isPresented: $isShowingSheet) {
    SomeView()
        .presentationDetents([.medium, .large]) // 또는 [.height(560)]
}

```
- Enum 타입에서 CaseIterable와 id: Self { self } 조합은 왜 자주 쓰일까?
`enum`은:
1. **모든 케이스가 유한하고 고유**하며 (`CaseIterable`)
2. 각 케이스가 자체적으로 유일한 값이므로 → Identifiable로 바로 사용 가능
3. 굳이 `UUID()` 같은 걸 붙이지 않아도 self를 ID로 활용 가능
```swift
enum ChartRange: String, CaseIterable, Identifiable {
    case oneDay = "1d"
    case oneWeek = "5d"
    case oneMonth = "1mo"
    // ...
    
    var id: Self { self }   // 각 case 자체를 ID로 사용

    var title: String {
        switch self {
        case .oneDay: return "1D"
        case .oneWeek: return "1W"
        case .oneMonth: return "1M"
        }
    }
}

사용부분

ForEach(ChartRange.allCases) { range in
    Text(range.title)
}
```
CaseIterable → .allCases 반복 가능

Identifiable → ForEach 등에서 고유 ID로 사용 가능

id: Self { self } → 별도 UUID 없이 enum 자체를 식별자로 활용
   - "내 ID는 나 자신(self)이다. 타입은 ChartRange(Self)다."
---

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #7 
